### PR TITLE
Security touch up

### DIFF
--- a/SafeAccountsAPI/Controllers/RefreshController.cs
+++ b/SafeAccountsAPI/Controllers/RefreshController.cs
@@ -20,12 +20,14 @@ namespace SafeAccountsAPI.Controllers
 
         private readonly APIContext _context; // database handle
         public IConfiguration _configuration; //config handle
+        public string[] _keyAndIV; // this is the key that is used at the top level encryption
 
         // get an instance of a database and http handle
         public RefreshController(APIContext context, IHttpContextAccessor httpContextAccessor, IConfiguration configuration)
         {
             _context = context;
             _configuration = configuration;
+            _keyAndIV = new string[] { _configuration.GetValue<string>("UserEncryptionKey"), _configuration.GetValue<string>("UserEncryptionIV") };
         }
 
 
@@ -52,18 +54,18 @@ namespace SafeAccountsAPI.Controllers
             User user = HelperMethods.GetUserFromAccessToken(Request.Cookies["AccessTokenSameSite"] ?? Request.Cookies["AccessToken"], _context, _configuration.GetValue<string>("UserJwtTokenKey"));
 
             // make sure this is a valid token for the user
-            if (!HelperMethods.ValidateRefreshToken(user, Request.Cookies["RefreshTokenSameSite"] ?? Request.Cookies["RefreshToken"]))
+            if (!HelperMethods.ValidateRefreshToken(user, Request.Cookies["RefreshTokenSameSite"] ?? Request.Cookies["RefreshToken"], _keyAndIV))
             {
                 ErrorMessage error = new ErrorMessage("Invalid refresh token", "Refrsh token could not be validated.");
                 return new BadRequestObjectResult(error);
             }
 
             string newTokenStr = HelperMethods.GenerateJWTAccessToken(user.ID, _configuration.GetValue<string>("UserJwtTokenKey"));
-            RefreshToken newRefToken = HelperMethods.GenerateRefreshToken(user, _context);
-            LoginResponse rtrn = new LoginResponse { ID = user.ID, AccessToken = newTokenStr, RefreshToken = new ReturnableRefreshToken(newRefToken) };
+            RefreshToken newRefToken = HelperMethods.GenerateRefreshToken(user, _context, _keyAndIV);
+            LoginResponse rtrn = new LoginResponse { ID = user.ID, AccessToken = newTokenStr, RefreshToken = new ReturnableRefreshToken(newRefToken, _keyAndIV) };
 
             // append cookies after refresh
-            HelperMethods.SetCookies(Response, newTokenStr, newRefToken);
+            HelperMethods.SetCookies(Response, newTokenStr, newRefToken, _keyAndIV);
             return new OkObjectResult(rtrn);
         }
     }

--- a/SafeAccountsAPI/Data/DbInitializer.cs
+++ b/SafeAccountsAPI/Data/DbInitializer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Text;
 using Microsoft.Extensions.Configuration;
 using SafeAccountsAPI.Helpers;
 using SafeAccountsAPI.Models;
@@ -67,12 +68,14 @@ namespace SafeAccountsAPI.Data
                     context.Users.Add(person); // add each user to the table
 
                 context.SaveChanges(); // execute changes
-
-                // create a key and iv for these base users
-                foreach (User person in context.Users)
-                    HelperMethods.CreateUserKeyandIV(person.ID);
             }
 
+            /*
+             * For now these accounts will be unencrypted just to ensure db connection..
+             * For the testers, it is just the byte arrays
+             *
+             * Our client side application will be doing the encryption and the api will only ever send and recieve encrypted hex strings
+             */
             if (!context.Accounts.Any())
             {
                 // add 2 base accounts to each user for testing
@@ -80,102 +83,102 @@ namespace SafeAccountsAPI.Data
                 {
                     new Account {
                         UserID=1,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("gmail", HelperMethods.GetUserKeyAndIV(1)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("johndoe", HelperMethods.GetUserKeyAndIV(1)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(1)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(1)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(1)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(1)),
+                        Title=Encoding.UTF8.GetBytes("gmail"),
+                        Login=Encoding.UTF8.GetBytes("johndoe"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=1,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("yahoo", HelperMethods.GetUserKeyAndIV(1)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("johndoe", HelperMethods.GetUserKeyAndIV(1)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(1)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(1)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(1)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(1)),
+                        Title=Encoding.UTF8.GetBytes("yahoo"),
+                        Login=Encoding.UTF8.GetBytes("johndoe"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=2,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("paypal", HelperMethods.GetUserKeyAndIV(2)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("edwinmay", HelperMethods.GetUserKeyAndIV(2)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(2)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(2)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(2)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(2)),
+                        Title=Encoding.UTF8.GetBytes("paypal"),
+                        Login=Encoding.UTF8.GetBytes("edwinmay"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=2,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("zoom", HelperMethods.GetUserKeyAndIV(2)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("edwinmay", HelperMethods.GetUserKeyAndIV(2)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(2)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(2)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(2)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(2)),
+                        Title=Encoding.UTF8.GetBytes("zoom"),
+                        Login=Encoding.UTF8.GetBytes("edwinmay"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=3,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("chase", HelperMethods.GetUserKeyAndIV(3)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("lucyvale", HelperMethods.GetUserKeyAndIV(3)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(3)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(3)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(3)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(3)),
+                        Title=Encoding.UTF8.GetBytes("chase"),
+                        Login=Encoding.UTF8.GetBytes("lucyvale"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=3,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("netflix", HelperMethods.GetUserKeyAndIV(3)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("lucyvale", HelperMethods.GetUserKeyAndIV(3)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(3)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(3)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(3)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(3)),
+                        Title=Encoding.UTF8.GetBytes("netflix"),
+                        Login=Encoding.UTF8.GetBytes("lucyvale"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=4,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("hulu", HelperMethods.GetUserKeyAndIV(4)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("pamwillis", HelperMethods.GetUserKeyAndIV(4)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(4)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(4)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(4)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(4)),
+                        Title=Encoding.UTF8.GetBytes("hulu"),
+                        Login=Encoding.UTF8.GetBytes("pamwillis"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=4,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("amazon", HelperMethods.GetUserKeyAndIV(4)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("pamwillis", HelperMethods.GetUserKeyAndIV(4)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(4)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(4)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(4)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(4)),
+                        Title=Encoding.UTF8.GetBytes("amazon"),
+                        Login=Encoding.UTF8.GetBytes("pamwillis"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=5,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("spotify", HelperMethods.GetUserKeyAndIV(5)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("gamestonk", HelperMethods.GetUserKeyAndIV(5)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(5)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(5)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(5)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(5)),
+                        Title=Encoding.UTF8.GetBytes("spotify"),
+                        Login=Encoding.UTF8.GetBytes("gamestonk"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                     new Account {
                         UserID=5,
-                        Title=HelperMethods.EncryptStringToBytes_Aes("bestbuy", HelperMethods.GetUserKeyAndIV(5)),
-                        Login=HelperMethods.EncryptStringToBytes_Aes("gamestonk", HelperMethods.GetUserKeyAndIV(5)),
-                        Password=HelperMethods.EncryptStringToBytes_Aes("useless", HelperMethods.GetUserKeyAndIV(5)),
-                        Url=HelperMethods.EncryptStringToBytes_Aes("testurl.com", HelperMethods.GetUserKeyAndIV(5)),
-                        Description=HelperMethods.EncryptStringToBytes_Aes("description...", HelperMethods.GetUserKeyAndIV(5)),
-                        LastModified=HelperMethods.EncryptStringToBytes_Aes(DateTime.Now.ToString(), HelperMethods.GetUserKeyAndIV(5)),
+                        Title=Encoding.UTF8.GetBytes("bestbuy"),
+                        Login=Encoding.UTF8.GetBytes("gamestonk"),
+                        Password=Encoding.UTF8.GetBytes("useless"),
+                        Url=Encoding.UTF8.GetBytes("testurl.com"),
+                        Description=Encoding.UTF8.GetBytes("description..."),
+                        LastModified=DateTime.Now.ToString(),
                         IsFavorite=false
                     },
                 };
@@ -184,25 +187,32 @@ namespace SafeAccountsAPI.Data
                 context.SaveChanges(); // execute changes
             }
 
+
+            /*
+             * For now these folders will be unencrypted just to ensure db connection..
+             * For the testers, it is just the byte arrays
+             *
+             * Our client side application will be doing the encryption and the api will only ever send and recieve encrypted data
+             */
             if (!context.Folders.Any())
             {
                 // add base folders
                 Folder[] base_folds = new Folder[]
                 {
-                    new Folder { UserID=1, FolderName=HelperMethods.EncryptStringToBytes_Aes("Folder", HelperMethods.GetUserKeyAndIV(1)), HasChild =true },
-                    new Folder { UserID=2, FolderName=HelperMethods.EncryptStringToBytes_Aes("Folder", HelperMethods.GetUserKeyAndIV(2)), HasChild=true },
-                    new Folder { UserID=3, FolderName=HelperMethods.EncryptStringToBytes_Aes("Folder", HelperMethods.GetUserKeyAndIV(3)), HasChild=true },
-                    new Folder { UserID=4, FolderName=HelperMethods.EncryptStringToBytes_Aes("Folder", HelperMethods.GetUserKeyAndIV(4)), HasChild=true },
-                    new Folder { UserID=5, FolderName=HelperMethods.EncryptStringToBytes_Aes("Folder", HelperMethods.GetUserKeyAndIV(5)), HasChild=true }
+                    new Folder { UserID=1, FolderName=Encoding.UTF8.GetBytes("Folder"), HasChild =true },
+                    new Folder { UserID=2, FolderName=Encoding.UTF8.GetBytes("Folder"), HasChild=true },
+                    new Folder { UserID=3, FolderName=Encoding.UTF8.GetBytes("Folder"), HasChild=true },
+                    new Folder { UserID=4, FolderName=Encoding.UTF8.GetBytes("Folder"), HasChild=true },
+                    new Folder { UserID=5, FolderName=Encoding.UTF8.GetBytes("Folder"), HasChild=true }
                 };
 
                 Folder[] sub_folds = new Folder[]
                 {
-                    new Folder { UserID=1, FolderName=HelperMethods.EncryptStringToBytes_Aes("Sub-Folder", HelperMethods.GetUserKeyAndIV(1)), HasChild=false, ParentID=5 },
-                    new Folder { UserID=2, FolderName=HelperMethods.EncryptStringToBytes_Aes("Sub-Folder", HelperMethods.GetUserKeyAndIV(2)), HasChild=false, ParentID=4 },
-                    new Folder { UserID=3, FolderName=HelperMethods.EncryptStringToBytes_Aes("Sub-Folder", HelperMethods.GetUserKeyAndIV(3)), HasChild=false, ParentID=3 },
-                    new Folder { UserID=4, FolderName=HelperMethods.EncryptStringToBytes_Aes("Sub-Folder", HelperMethods.GetUserKeyAndIV(4)), HasChild=false, ParentID=2 },
-                    new Folder { UserID=5, FolderName=HelperMethods.EncryptStringToBytes_Aes("Sub-Folder", HelperMethods.GetUserKeyAndIV(5)), HasChild=false, ParentID=1 }
+                    new Folder { UserID=1, FolderName=Encoding.UTF8.GetBytes("Sub-Folder"), HasChild=false, ParentID=5 },
+                    new Folder { UserID=2, FolderName=Encoding.UTF8.GetBytes("Sub-Folder"), HasChild=false, ParentID=4 },
+                    new Folder { UserID=3, FolderName=Encoding.UTF8.GetBytes("Sub-Folder"), HasChild=false, ParentID=3 },
+                    new Folder { UserID=4, FolderName=Encoding.UTF8.GetBytes("Sub-Folder"), HasChild=false, ParentID=2 },
+                    new Folder { UserID=5, FolderName=Encoding.UTF8.GetBytes("Sub-Folder"), HasChild=false, ParentID=1 }
                 };
 
                 foreach (Folder fold in base_folds) { context.Folders.Add(fold); } // add each account to the table

--- a/SafeAccountsAPI/Helpers/HelperMethods.cs
+++ b/SafeAccountsAPI/Helpers/HelperMethods.cs
@@ -11,6 +11,7 @@ using Microsoft.IdentityModel.Tokens;
 using SafeAccountsAPI.Data;
 using SafeAccountsAPI.Models;
 using SafeAccountsAPI.Logging;
+using Konscious.Security.Cryptography;
 
 namespace SafeAccountsAPI.Helpers
 {
@@ -177,23 +178,13 @@ namespace SafeAccountsAPI.Helpers
 
         public static byte[] GenerateSaltedHash(byte[] plainText, byte[] salt)
         {
-            HashAlgorithm algorithm = new SHA256Managed();
+            Argon2id hash = new Argon2id(plainText);
+            hash.Salt = salt;
+            hash.DegreeOfParallelism = 8;
+            hash.Iterations = 4;
+            hash.MemorySize = 1024 * 1024; // 1 GB
 
-
-            byte[] plainTextWithSaltBytes =
-              new byte[plainText.Length + salt.Length];
-
-            // prepend salt
-            for (int i = 0; i < salt.Length; i++)
-            {
-                plainTextWithSaltBytes[plainText.Length + i] = salt[i];
-            }
-            for (int i = 0; i < plainText.Length; i++)
-            {
-                plainTextWithSaltBytes[i] = plainText[i];
-            }
-
-            return algorithm.ComputeHash(plainTextWithSaltBytes);
+            return hash.GetBytes(32); // 32 bytes == 256 bits .. 
         }
 
         public static byte[] ConcatenatedSaltAndSaltedHash(string passwordStr)

--- a/SafeAccountsAPI/Models/Account.cs
+++ b/SafeAccountsAPI/Models/Account.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using SafeAccountsAPI.Helpers;
 
 namespace SafeAccountsAPI.Models
@@ -15,7 +16,7 @@ namespace SafeAccountsAPI.Models
         public byte[] Password { get; set; }
         public byte[] Url { get; set; }
         public byte[] Description { get; set; }
-        public byte[] LastModified { get; set; }
+        public string LastModified { get; set; }
         public bool IsFavorite { get; set; }
 
         public Account() { } // blank constructor needed for db initializer
@@ -24,11 +25,11 @@ namespace SafeAccountsAPI.Models
         public Account(NewAccount newAcc, int uid)
         {
             UserID = uid;
-            Title = HelperMethods.EncryptStringToBytes_Aes(newAcc.Title, HelperMethods.GetUserKeyAndIV(uid));
-            Login = HelperMethods.EncryptStringToBytes_Aes(newAcc.Login, HelperMethods.GetUserKeyAndIV(uid));
-            Password = HelperMethods.EncryptStringToBytes_Aes(newAcc.Password, HelperMethods.GetUserKeyAndIV(uid));
-            Url = HelperMethods.EncryptStringToBytes_Aes(newAcc.Url, HelperMethods.GetUserKeyAndIV(uid));
-            Description = HelperMethods.EncryptStringToBytes_Aes(newAcc.Description, HelperMethods.GetUserKeyAndIV(uid));
+            Title = HelperMethods.HexStringToByteArray(newAcc.Title);
+            Login = HelperMethods.HexStringToByteArray(newAcc.Login);
+            Password = HelperMethods.HexStringToByteArray(newAcc.Password);
+            Url = HelperMethods.HexStringToByteArray(newAcc.Url);
+            Description = HelperMethods.HexStringToByteArray(newAcc.Description);
             FolderID = newAcc.FolderID;
             IsFavorite = false;
         }
@@ -49,12 +50,12 @@ namespace SafeAccountsAPI.Models
         public ReturnableAccount(Account acc)
         {
             ID = acc.ID;
-            Title = HelperMethods.DecryptStringFromBytes_Aes(acc.Title, HelperMethods.GetUserKeyAndIV(acc.UserID));
-            Login = HelperMethods.DecryptStringFromBytes_Aes(acc.Login, HelperMethods.GetUserKeyAndIV(acc.UserID));
-            Password = HelperMethods.DecryptStringFromBytes_Aes(acc.Password, HelperMethods.GetUserKeyAndIV(acc.UserID));
-            Url = HelperMethods.DecryptStringFromBytes_Aes(acc.Url, HelperMethods.GetUserKeyAndIV(acc.UserID));
-            Description = HelperMethods.DecryptStringFromBytes_Aes(acc.Description, HelperMethods.GetUserKeyAndIV(acc.UserID));
-            LastModified = HelperMethods.DecryptStringFromBytes_Aes(acc.LastModified, HelperMethods.GetUserKeyAndIV(acc.UserID));
+            Title = BitConverter.ToString(acc.Title).Replace("-", "");
+            Login = BitConverter.ToString(acc.Login).Replace("-", "");
+            Password = BitConverter.ToString(acc.Password).Replace("-", "");
+            Url = BitConverter.ToString(acc.Url).Replace("-", "");
+            Description = BitConverter.ToString(acc.Description).Replace("-", "");
+            LastModified = acc.LastModified;
             IsFavorite = acc.IsFavorite;
 
             if (acc.FolderID != null)

--- a/SafeAccountsAPI/Models/Folder.cs
+++ b/SafeAccountsAPI/Models/Folder.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using SafeAccountsAPI.Helpers;
 
 namespace SafeAccountsAPI.Models
@@ -18,7 +19,7 @@ namespace SafeAccountsAPI.Models
         // constructor to easily set from NewFolder type
         public Folder(NewFolder newFolder, int uid)
         {
-            FolderName = HelperMethods.EncryptStringToBytes_Aes(newFolder.Folder_Name, HelperMethods.GetUserKeyAndIV(uid));
+            FolderName = HelperMethods.HexStringToByteArray(newFolder.Folder_Name);
             UserID = uid;
             ParentID = newFolder.Parent_ID;
             HasChild = false;
@@ -36,7 +37,7 @@ namespace SafeAccountsAPI.Models
         public ReturnableFolder(Folder fold)
         {
             ID = fold.ID;
-            FolderName = HelperMethods.DecryptStringFromBytes_Aes(fold.FolderName, HelperMethods.GetUserKeyAndIV(fold.UserID));
+            FolderName = BitConverter.ToString(fold.FolderName).Replace("-", "");
             HasChild = fold.HasChild;
 
             if (fold.ParentID != null)

--- a/SafeAccountsAPI/Models/RefreshToken.cs
+++ b/SafeAccountsAPI/Models/RefreshToken.cs
@@ -16,10 +16,10 @@ namespace SafeAccountsAPI.Models
         public string Token { get; set; }
         public string Expiration { get; set; }
 
-        public ReturnableRefreshToken(RefreshToken rt)
+        public ReturnableRefreshToken(RefreshToken rt, string[] keyAndIv)
         {
-            Token = HelperMethods.DecryptStringFromBytes_Aes(rt.Token, HelperMethods.GetUserKeyAndIV(rt.UserID));
-            Expiration = HelperMethods.DecryptStringFromBytes_Aes(rt.Expiration, HelperMethods.GetUserKeyAndIV(rt.UserID));
+            Token = HelperMethods.DecryptStringFromBytes_Aes(rt.Token, keyAndIv);
+            Expiration = HelperMethods.DecryptStringFromBytes_Aes(rt.Expiration, keyAndIv);
         }
     }
 }

--- a/SafeAccountsAPI/SafeAccountsAPI.csproj
+++ b/SafeAccountsAPI/SafeAccountsAPI.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Konscious.Security.Cryptography.Argon2" Version="1.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="5.0.6" />

--- a/SafeAccountsAPI/SafeAccountsAPI.postman_collection.json
+++ b/SafeAccountsAPI/SafeAccountsAPI.postman_collection.json
@@ -39,7 +39,7 @@
 												"header": [],
 												"body": {
 													"mode": "raw",
-													"raw": "\"alsouseless\"",
+													"raw": "\"616c736f7573656c657373\"",
 													"options": {
 														"raw": {
 															"language": "json"
@@ -60,7 +60,8 @@
 														"4",
 														"password"
 													]
-												}
+												},
+												"description": "New Password: alsouseless\n\n* Note: value is a hex string"
 											},
 											"response": []
 										},
@@ -94,7 +95,7 @@
 													}
 												},
 												"url": {
-													"raw": "https://localhost:44366/users/1/accounts/4/folder",
+													"raw": "https://localhost:44366/users/1/accounts/28/folder",
 													"protocol": "https",
 													"host": [
 														"localhost"
@@ -104,7 +105,7 @@
 														"users",
 														"1",
 														"accounts",
-														"4",
+														"28",
 														"folder"
 													]
 												}
@@ -133,7 +134,7 @@
 												"header": [],
 												"body": {
 													"mode": "raw",
-													"raw": "\"new description\"",
+													"raw": "\"6e6577206465736372697074696f6e\"",
 													"options": {
 														"raw": {
 															"language": "json"
@@ -154,7 +155,8 @@
 														"4",
 														"description"
 													]
-												}
+												},
+												"description": "New Description: new description\n\n* Note: value is a hex string"
 											},
 											"response": []
 										},
@@ -180,7 +182,7 @@
 												"header": [],
 												"body": {
 													"mode": "raw",
-													"raw": "\"new title\"",
+													"raw": "\"6e6577207469746c65\"",
 													"options": {
 														"raw": {
 															"language": "json"
@@ -201,7 +203,8 @@
 														"4",
 														"title"
 													]
-												}
+												},
+												"description": "New Title: New Title\n\n* Note: value is a hex string"
 											},
 											"response": []
 										},
@@ -227,7 +230,7 @@
 												"header": [],
 												"body": {
 													"mode": "raw",
-													"raw": "\"new login\"",
+													"raw": "\"6e657720757365726e616d65\"",
 													"options": {
 														"raw": {
 															"language": "json"
@@ -235,7 +238,7 @@
 													}
 												},
 												"url": {
-													"raw": "https://localhost:44366/users/1/accounts/5/login",
+													"raw": "https://localhost:44366/users/1/accounts/4/login",
 													"protocol": "https",
 													"host": [
 														"localhost"
@@ -245,10 +248,11 @@
 														"users",
 														"1",
 														"accounts",
-														"5",
+														"4",
 														"login"
 													]
-												}
+												},
+												"description": "New Login: new username\n\n* Note: value is a hex string"
 											},
 											"response": []
 										},
@@ -325,6 +329,53 @@
 												}
 											},
 											"response": []
+										},
+										{
+											"name": "favorite",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "value",
+															"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+															"type": "string"
+														},
+														{
+															"key": "key",
+															"value": "ApiKey",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "true",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "https://localhost:44366/users/1/accounts/5/favorite",
+													"protocol": "https",
+													"host": [
+														"localhost"
+													],
+													"port": "44366",
+													"path": [
+														"users",
+														"1",
+														"accounts",
+														"5",
+														"favorite"
+													]
+												}
+											},
+											"response": []
 										}
 									]
 								},
@@ -389,7 +440,7 @@
 										"header": [],
 										"body": {
 											"mode": "raw",
-											"raw": "{\"title\":\"title2\", \"login\":\"login\", \"password\":\"useless\", \"url\":\"testurl.com\", \"description\":\"description\", \"folderid\": 5}",
+											"raw": "{\r\n    \"title\":\"446973636f7264\", \r\n    \"login\":\"757365726e616d65\", \r\n    \"password\":\"7573656c657373\", \r\n    \"url\":\"68747470733a2f2f646973636f72642e636f6d\", \r\n    \"description\":\"6465736372697074696f6e2e2e2e\"\r\n}",
 											"options": {
 												"raw": {
 													"language": "json"
@@ -456,6 +507,53 @@
 										}
 									},
 									"response": []
+								},
+								{
+									"name": "{accounts}",
+									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "value",
+													"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+													"type": "string"
+												},
+												{
+													"key": "key",
+													"value": "ApiKey",
+													"type": "string"
+												}
+											]
+										},
+										"method": "PUT",
+										"header": [],
+										"body": {
+											"mode": "raw",
+											"raw": "{\r\n    \"title\":\"446973636f7264\", \r\n    \"login\":\"757365726e616d65\", \r\n    \"password\":\"7573656c6573736572\",\r\n    \"url\":\"68747470733a2f2f646973636f72642e636f6d\", \r\n    \"description\":\"6465736372697074696f6e2e2e2e\"\r\n}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "https://localhost:44366/users/1/accounts/4",
+											"protocol": "https",
+											"host": [
+												"localhost"
+											],
+											"port": "44366",
+											"path": [
+												"users",
+												"1",
+												"accounts",
+												"4"
+											]
+										},
+										"description": "new password: uselesser\n\n*Note: all hex string values"
+									},
+									"response": []
 								}
 							]
 						},
@@ -468,10 +566,25 @@
 										{
 											"name": "{id}",
 											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "value",
+															"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+															"type": "string"
+														},
+														{
+															"key": "key",
+															"value": "ApiKey",
+															"type": "string"
+														}
+													]
+												},
 												"method": "DELETE",
 												"header": [],
 												"url": {
-													"raw": "https://localhost:44366/users/1/folders/10",
+													"raw": "https://localhost:44366/users/1/folders/11",
 													"protocol": "https",
 													"host": [
 														"localhost"
@@ -481,7 +594,101 @@
 														"users",
 														"1",
 														"folders",
-														"10"
+														"11"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "parent",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "value",
+															"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+															"type": "string"
+														},
+														{
+															"key": "key",
+															"value": "ApiKey",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "12",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "https://localhost:44366/users/1/folders/5/parent",
+													"protocol": "https",
+													"host": [
+														"localhost"
+													],
+													"port": "44366",
+													"path": [
+														"users",
+														"1",
+														"folders",
+														"5",
+														"parent"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "name",
+											"request": {
+												"auth": {
+													"type": "apikey",
+													"apikey": [
+														{
+															"key": "value",
+															"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+															"type": "string"
+														},
+														{
+															"key": "key",
+															"value": "ApiKey",
+															"type": "string"
+														}
+													]
+												},
+												"method": "PUT",
+												"header": [],
+												"body": {
+													"mode": "raw",
+													"raw": "\"4e657720466f6c646572\"",
+													"options": {
+														"raw": {
+															"language": "json"
+														}
+													}
+												},
+												"url": {
+													"raw": "https://localhost:44366/users/1/folders/5/name",
+													"protocol": "https",
+													"host": [
+														"localhost"
+													],
+													"port": "44366",
+													"path": [
+														"users",
+														"1",
+														"folders",
+														"5",
+														"name"
 													]
 												}
 											},
@@ -492,6 +699,21 @@
 								{
 									"name": "{folders}",
 									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "value",
+													"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+													"type": "string"
+												},
+												{
+													"key": "key",
+													"value": "ApiKey",
+													"type": "string"
+												}
+											]
+										},
 										"method": "GET",
 										"header": [],
 										"url": {
@@ -513,9 +735,45 @@
 								{
 									"name": "{folders}",
 									"request": {
+										"auth": {
+											"type": "apikey",
+											"apikey": [
+												{
+													"key": "value",
+													"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
+													"type": "string"
+												},
+												{
+													"key": "key",
+													"value": "ApiKey",
+													"type": "string"
+												}
+											]
+										},
 										"method": "POST",
 										"header": [],
-										"url": null
+										"body": {
+											"mode": "raw",
+											"raw": "{\"folder_name\": \"4e657720466f6c646572\", \"parentId\": null}",
+											"options": {
+												"raw": {
+													"language": "json"
+												}
+											}
+										},
+										"url": {
+											"raw": "https://localhost:44366/users/1/folders",
+											"protocol": "https",
+											"host": [
+												"localhost"
+											],
+											"port": "44366",
+											"path": [
+												"users",
+												"1",
+												"folders"
+											]
+										}
 									},
 									"response": []
 								}
@@ -586,54 +844,6 @@
 									"path": [
 										"users",
 										"7"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "firstname",
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							},
-							"request": {
-								"auth": {
-									"type": "apikey",
-									"apikey": [
-										{
-											"key": "value",
-											"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwOi8vc2NoZW1hcy54bWxzb2FwLm9yZy93cy8yMDA1LzA1L2lkZW50aXR5L2NsYWltcy9uYW1lIjoiYXBpX2tleSIsImV4cCI6MTY1MzkxODQyNiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIiwiYXVkIjoiaHR0cDovL2xvY2FsaG9zdDo1MDAwIn0.ZBagEGyp7dJBozJ7HoQ8nZVNpK-h-rzjXL9SmEvIYgA",
-											"type": "string"
-										},
-										{
-											"key": "key",
-											"value": "ApiKey",
-											"type": "string"
-										}
-									]
-								},
-								"method": "GET",
-								"header": [],
-								"body": {
-									"mode": "raw",
-									"raw": "\"john\"",
-									"options": {
-										"raw": {
-											"language": "json"
-										}
-									}
-								},
-								"url": {
-									"raw": "https://localhost:44366/users/1/firstname",
-									"protocol": "https",
-									"host": [
-										"localhost"
-									],
-									"port": "44366",
-									"path": [
-										"users",
-										"1",
-										"firstname"
 									]
 								}
 							},
@@ -885,14 +1095,13 @@
 						"method": "POST",
 						"header": [],
 						"url": {
-							"raw": "https://localhost:44305/api/users/logout",
+							"raw": "https://localhost:44366/users/logout",
 							"protocol": "https",
 							"host": [
 								"localhost"
 							],
-							"port": "44305",
+							"port": "44366",
 							"path": [
-								"api",
 								"users",
 								"logout"
 							]

--- a/SafeAccountsAPI/TableCreations_MySQL.sql
+++ b/SafeAccountsAPI/TableCreations_MySQL.sql
@@ -23,7 +23,7 @@ Create Table Folders
     UserID int not null,
     ParentID int,
     HasChild bool not null,
-    FolderName varbinary(200),
+    FolderName varbinary(32), /*n-1 chars can be saved aes encrypted*/
     Constraint FK_Folders_UserID foreign key (UserID)
     references Users(ID),
     Constraint FK_Folders_ParentID foreign key (ParentID)
@@ -35,11 +35,11 @@ Create Table Accounts
 	ID int primary key auto_increment,
 	UserID int not null,
     FolderID int,
-	Title varbinary(200),
-	Login varbinary(200),
-	Password varbinary(200),
-    Url varbinary(200),
-	Description varbinary(600),
+	Title varbinary(64), /*n-1 chars can be saved aes encrypted*/
+	Login varbinary(48),
+	Password varbinary(48),
+    Url varbinary(192),
+	Description varbinary(592),
     LastModified varbinary(200),
     IsFavorite bool not null,
     CONSTRAINT FK_Accounts_UserID FOREIGN KEY (UserID)

--- a/SafeAccountsAPI/TableCreations_MySQL.sql
+++ b/SafeAccountsAPI/TableCreations_MySQL.sql
@@ -40,7 +40,7 @@ Create Table Accounts
 	Password varbinary(48),
     Url varbinary(192),
 	Description varbinary(592),
-    LastModified varbinary(200),
+    LastModified nvarchar(50), /*simple date string*/
     IsFavorite bool not null,
     CONSTRAINT FK_Accounts_UserID FOREIGN KEY (UserID)
     REFERENCES Users(ID),


### PR DESCRIPTION
* Change password hash to argon2id.
* Fix up security model to no longer store user encryption keys on the server.
* API now sends and receives data that is expected to be encrypted client side. Input for newly saved accounts will come in as hex strings and be stored back as byte arrays. **Note:** This change in logic required multiple files to update.
* Refresh tokens no longer encrypted with user specific key.
* Updated unit tests.
* Update allowed lengths of data table rows.